### PR TITLE
⚡ Optimize ForEach-Object pipelines with foreach keywords

### DIFF
--- a/pacwin.psm1
+++ b/pacwin.psm1
@@ -233,7 +233,7 @@ function _pw_search_all {
         } -ThrottleLimit 3
         
         foreach ($res in $jobResults) {
-            $lines = @($res.Raw | ForEach-Object { "$_" })
+            $lines = @(foreach ($item in $res.Raw) { "$item" })
             switch ($res.Key) {
                 "winget" { $parsed = _pw_parse_winget_lines $lines }
                 "choco"  { $parsed = _pw_parse_choco_lines  $lines }
@@ -263,7 +263,7 @@ function _pw_search_all {
             }
             if ($rs.AsyncResult.IsCompleted) {
                 $raw = $rs.PowerShell.EndInvoke($rs.AsyncResult)
-                $lines = @($raw | ForEach-Object { "$_" })
+                $lines = @(foreach ($item in $raw) { "$item" })
                 switch ($rs.Key) {
                     "winget" { $parsed = _pw_parse_winget_lines $lines }
                     "choco"  { $parsed = _pw_parse_choco_lines  $lines }
@@ -788,7 +788,7 @@ function _pw_do_sync {
 
     if ($managers["winget"]) {
         $raw = winget list --accept-source-agreements 2>$null
-        $lines = @($raw | ForEach-Object { "$_" })
+        $lines = @(foreach ($item in $raw) { "$item" })
         $parsed = _pw_parse_winget_lines $lines
         foreach ($p in $parsed) { $installed.Add($p) }
     }
@@ -952,7 +952,7 @@ function _pw_do_outdated {
     if ($managers["winget"]) {
         if (-not $Silent) { _pw_color "  -- winget -----------------------------" Cyan }
         $out = winget upgrade --accept-source-agreements 2>$null
-        $lines = @($out | ForEach-Object { "$_" })
+        $lines = @(foreach ($item in $out) { "$item" })
         $parsed = _pw_parse_winget_lines $lines
         foreach ($p in $parsed) { $allResults.Add($p) }
     }


### PR DESCRIPTION
💡 **What:** Replaced the pipeline-based `@($raw | ForEach-Object { "$_" })` string transformation logic with native `foreach` keyword statements (`@(foreach ($item in $raw) { "$item" })`) in multiple places across `pacwin.psm1`.

🎯 **Why:** To improve performance by eliminating pipeline overhead, which can be significant when dealing with potentially large arrays of strings from package managers. This change replaces the slower `ForEach-Object` pipeline with a more performant syntax.

📊 **Measured Improvement:** Unable to provide local benchmark measurements as `pwsh` is not available on the current Linux devbox, making testing and benchmarking impractical in this environment. However, this is a standard and well-documented performance improvement technique in PowerShell as language statement keywords do not incur pipeline binding and teardown overhead costs for each object.

---
*PR created automatically by Jules for task [16821108241829593562](https://jules.google.com/task/16821108241829593562) started by @julesklord*