### PR TITLE
⚡ Replace slow ForEach-Object with foreach loop for stringification

### DIFF
--- a/pacwin.psm1
+++ b/pacwin.psm1
@@ -233,7 +233,7 @@ function _pw_search_all {
         } -ThrottleLimit 3
         
         foreach ($res in $jobResults) {
-            $lines = @($res.Raw | ForEach-Object { "$_" })
+            $lines = @(foreach ($line in $res.Raw) { "$line" })
             switch ($res.Key) {
                 "winget" { $parsed = _pw_parse_winget_lines $lines }
                 "choco"  { $parsed = _pw_parse_choco_lines  $lines }
@@ -263,7 +263,7 @@ function _pw_search_all {
             }
             if ($rs.AsyncResult.IsCompleted) {
                 $raw = $rs.PowerShell.EndInvoke($rs.AsyncResult)
-                $lines = @($raw | ForEach-Object { "$_" })
+                $lines = @(foreach ($line in $raw) { "$line" })
                 switch ($rs.Key) {
                     "winget" { $parsed = _pw_parse_winget_lines $lines }
                     "choco"  { $parsed = _pw_parse_choco_lines  $lines }
@@ -788,7 +788,7 @@ function _pw_do_sync {
 
     if ($managers["winget"]) {
         $raw = winget list --accept-source-agreements 2>$null
-        $lines = @($raw | ForEach-Object { "$_" })
+        $lines = @(foreach ($line in $raw) { "$line" })
         $parsed = _pw_parse_winget_lines $lines
         foreach ($p in $parsed) { $installed.Add($p) }
     }
@@ -952,7 +952,7 @@ function _pw_do_outdated {
     if ($managers["winget"]) {
         if (-not $Silent) { _pw_color "  -- winget -----------------------------" Cyan }
         $out = winget upgrade --accept-source-agreements 2>$null
-        $lines = @($out | ForEach-Object { "$_" })
+        $lines = @(foreach ($line in $out) { "$line" })
         $parsed = _pw_parse_winget_lines $lines
         foreach ($p in $parsed) { $allResults.Add($p) }
     }

--- a/tests/test_pester_results.ps1
+++ b/tests/test_pester_results.ps1
@@ -245,7 +245,7 @@ function _pw_search_all {
         $finished = $job | Wait-Job -Timeout 25
         if ($finished) {
             $raw = Receive-Job $job -ErrorAction SilentlyContinue
-            $lines = @($raw | ForEach-Object { "$_" })
+            $lines = @(foreach ($line in $raw) { "$line" })
             switch ($key) {
                 "winget" { $parsed = _pw_parse_winget_lines $lines }
                 "choco" { $parsed = _pw_parse_choco_lines  $lines }


### PR DESCRIPTION
💡 **What:** Replaced the use of `ForEach-Object` pipeline with the `foreach` statement loop when converting outputs into string arrays.
🎯 **Why:** Pipeline overhead in PowerShell makes `ForEach-Object` noticeably slower than the `foreach` statement. This is a straightforward syntax transformation to eliminate the object creation and pipeline bindings for performance-critical string transformations.
📊 **Measured Improvement:** I am currently in a development environment without the `pwsh` executable and am unable to perform measurements. However, eliminating pipeline bindings to stringify primitive arrays using the `foreach` statement is a well-known optimization in PowerShell scripts.

---
*PR created automatically by Jules for task [732136526178463536](https://jules.google.com/task/732136526178463536) started by @julesklord*