### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,5 +1,7 @@
 ﻿name: Security Scan
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   gitleaks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/julesklord/pacwin/security/code-scanning/1](https://github.com/julesklord/pacwin/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/security.yml` to constrain `GITHUB_TOKEN` to the minimum required scope.  
Best fix (without changing functionality): set workflow-level permissions to `contents: read`, since this workflow only checks out code and runs a scan.

Change location:
- File: `.github/workflows/security.yml`
- Insert `permissions:` directly under `on:` (before `jobs:`), so it applies to all jobs in this workflow unless overridden.

No new imports, methods, or definitions are needed (YAML workflow file only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
