### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/powershell-ci.yml
+++ b/.github/workflows/powershell-ci.yml
@@ -4,6 +4,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: windows-latest


### PR DESCRIPTION
Potential fix for [https://github.com/julesklord/pacwin/security/code-scanning/2](https://github.com/julesklord/pacwin/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is restricted to only what this CI job requires. The best fix here is to add workflow-level permissions directly under `name`/`on` (before `jobs`), setting:

- `contents: read`

This preserves current functionality (`actions/checkout` and test execution) while documenting and enforcing least privilege. No imports, methods, or extra definitions are needed—just YAML configuration in `.github/workflows/powershell-ci.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
