### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - v* # Se dispara cuando subís un tag como v0.2.4 
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: windows-latest


### PR DESCRIPTION
Potential fix for [https://github.com/julesklord/pacwin/security/code-scanning/3](https://github.com/julesklord/pacwin/security/code-scanning/3)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is constrained to least privilege.

Best fix (without changing behavior): define workflow-level permissions with `contents: read` near the top of `.github/workflows/publish.yml` (after `on:` block and before `jobs:`). This applies to all jobs in the workflow, including `publish`, and is sufficient for `actions/checkout` and the current publish logic (which uses `PSGALLERY_API_KEY`, not token write scopes).

No imports, methods, or additional definitions are needed—just YAML configuration in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
