### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/powershell-ci.yml
+++ b/.github/workflows/powershell-ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Pester Tests


### PR DESCRIPTION
Potential fix for [https://github.com/julesklord/pacwin/security/code-scanning/4](https://github.com/julesklord/pacwin/security/code-scanning/4)

Add an explicit `permissions` block at the workflow root in `.github/workflows/powershell-ci.yml`, immediately after the `on:` triggers (or before `jobs:`), to apply least-privilege defaults to all jobs in this workflow.

For this workflow, the best minimal non-breaking permission is:

- `contents: read`

This supports `actions/checkout` and does not grant unnecessary write scopes. No additional imports, methods, or definitions are needed because this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
