### PR TITLE
🧹 Code Health Improvement: Refactor deeply nested conditionals in updates

### DIFF
--- a/pacwin.psm1
+++ b/pacwin.psm1
@@ -505,36 +505,38 @@ function _pw_handle_update {
         [string]$Manager
     )
 
-    if ($Query) {
-        _pw_color "  Looking for update candidates for '$Query'..." Cyan
-        if ($Manager) {
-            _pw_do_update_single $Query $Manager
-        }
-        else {
-            _pw_color "  Searching in outdated packages..." Gray
-            $outdated = _pw_do_outdated $targetManagers -Silent
-            $targetMatches = @($outdated | Where-Object { $_.ID -eq $Query -or $_.Name -eq $Query })
-
-            if ($targetMatches.Count -eq 0) {
-                _pw_color "  No outdated package found matching '$Query'. Trying direct update..." Gray
-                foreach ($m in $targetManagers.Keys) {
-                    _pw_do_update_single $Query $m
-                }
-            }
-            elseif ($targetMatches.Count -eq 1) {
-                _pw_do_update_single $targetMatches[0].ID $targetMatches[0].Manager
-            }
-            else {
-                _pw_color "  Multiple managers have updates for '$Query':" Yellow
-                $pkg = _pw_pick_source $targetMatches
-                if ($pkg) {
-                    _pw_do_update_single $pkg.ID $pkg.Manager
-                }
-            }
-        }
-    }
-    else {
+    if (-not $Query) {
         _pw_do_update_all $targetManagers
+        return
+    }
+
+    _pw_color "  Looking for update candidates for '$Query'..." Cyan
+    if ($Manager) {
+        _pw_do_update_single $Query $Manager
+        return
+    }
+
+    _pw_color "  Searching in outdated packages..." Gray
+    $outdated = _pw_do_outdated $targetManagers -Silent
+    $targetMatches = @(@($outdated).Where({ $_.ID -eq $Query -or $_.Name -eq $Query }))
+
+    if ($targetMatches.Count -eq 0) {
+        _pw_color "  No outdated package found matching '$Query'. Trying direct update..." Gray
+        foreach ($m in $targetManagers.Keys) {
+            _pw_do_update_single $Query $m
+        }
+        return
+    }
+
+    if ($targetMatches.Count -eq 1) {
+        _pw_do_update_single $targetMatches[0].ID $targetMatches[0].Manager
+        return
+    }
+
+    _pw_color "  Multiple managers have updates for '$Query':" Yellow
+    $pkg = _pw_pick_source $targetMatches
+    if ($pkg) {
+        _pw_do_update_single $pkg.ID $pkg.Manager
     }
 }
 


### PR DESCRIPTION
🎯 **What:**
The code health issue addressed was a deeply nested conditional block in the `_pw_handle_update` function in `pacwin.psm1` (originally requested for line 392, corresponding to the update logic block in the source). Nested `if`/`else` structures spanning over 4 levels deep made the update logic harder to follow. 

💡 **Why:**
Using early returns instead of nested `else` and `elseif` blocks greatly flattens the cyclomatic complexity. This makes the execution flow cleaner and more linear, which improves code readability and maintainability.

✅ **Verification:**
* Verified that the exact execution logic and logic branches remain identical to the previous implementation.
* The tests (`pwsh -c "Invoke-Pester -Path ./tests -Output Detailed"`) run to ensure no regressions were introduced.
* Confirmed the `-WhatIf` logic remains un-affected implicitly by keeping the function definition untouched.

✨ **Result:**
The `_pw_handle_update` method is now completely un-nested, avoiding messy indentation limits and reducing visual complexity for future contributors while executing precisely the same logic paths.

---
*PR created automatically by Jules for task [10833865337417668627](https://jules.google.com/task/10833865337417668627) started by @julesklord*