### PR TITLE
🧹 Refactor deeply nested conditionals in winget parser

### DIFF
--- a/pacwin.psm1
+++ b/pacwin.psm1
@@ -197,24 +197,18 @@ function _pw_parse_winget_lines
             { continue
             }
             $parts = ($line.Trim() -split "\s{2,}").Where({ $_ -ne "" })
-            if ($parts.Count -ge 2)
-            {
-                $results.Add([PSCustomObject]@{
-                        Name    = $parts[0].Trim()
-                        ID      = $(if ($parts.Count -ge 3)
-                            { $parts[1].Trim()
-                            } else
-                            { $parts[0].Trim()
-                            })
-                        Version = $(if ($parts.Count -ge 3)
-                            { $parts[2].Trim()
-                            } else
-                            { $parts[1].Trim()
-                            })
-                        Source  = "winget"
-                        Manager = "winget"
-                    })
+            if ($parts.Count -lt 2)
+            { continue
             }
+            $id = if ($parts.Count -ge 3) { $parts[1].Trim() } else { $parts[0].Trim() }
+            $version = if ($parts.Count -ge 3) { $parts[2].Trim() } else { $parts[1].Trim() }
+            $results.Add([PSCustomObject]@{
+                    Name    = $parts[0].Trim()
+                    ID      = $id
+                    Version = $version
+                    Source  = "winget"
+                    Manager = "winget"
+                })
         }
         return $results
     }
@@ -372,13 +366,10 @@ function _pw_parse_scoop_lines
         $parts = ($line.Trim() -split "\s{2,}").Where({ $_ -ne "" })
         if ($parts.Count -ge 1 -and $parts[0] -notmatch "^[Nn]ame$|^Source$")
         {
+            $version = if ($parts.Count -ge 2) { $parts[1] } else { "?" }
             $results.Add([PSCustomObject]@{
                     Name = $parts[0]; ID = $parts[0]
-                    Version = $(if ($parts.Count -ge 2)
-                        { $parts[1]
-                        } else
-                        { "?"
-                        })
+                    Version = $version
                     Source = "scoop"; Manager = "scoop"
                 })
         }


### PR DESCRIPTION
🎯 What: Refactored the deeply nested conditionals inside `_pw_parse_winget_lines` and `_pw_parse_scoop_lines` in `pacwin.psm1`.
💡 Why: To improve code maintainability and readability by using early returns and extracting version assignment to avoid nested instantiation of `[PSCustomObject]`.
✅ Verification: Ran the Pester test suite to verify no regressions in winget and scoop output parsing. All tests passed.
✨ Result: The fallback parsing loop is now flatter and easier to understand without changing its functionality.

---
*PR created automatically by Jules for task [12445573916579285331](https://jules.google.com/task/12445573916579285331) started by @julesklord*