### PR TITLE
🧹 Refactor nested conditionals in parsers for better readability

### DIFF
--- a/pacwin.psm1
+++ b/pacwin.psm1
@@ -197,24 +197,18 @@ function _pw_parse_winget_lines
             { continue
             }
             $parts = ($line.Trim() -split "\s{2,}").Where({ $_ -ne "" })
-            if ($parts.Count -ge 2)
-            {
-                $results.Add([PSCustomObject]@{
-                        Name    = $parts[0].Trim()
-                        ID      = $(if ($parts.Count -ge 3)
-                            { $parts[1].Trim()
-                            } else
-                            { $parts[0].Trim()
-                            })
-                        Version = $(if ($parts.Count -ge 3)
-                            { $parts[2].Trim()
-                            } else
-                            { $parts[1].Trim()
-                            })
-                        Source  = "winget"
-                        Manager = "winget"
-                    })
+            if ($parts.Count -lt 2) {
+                continue
             }
+
+            $hasThreeParts = $parts.Count -ge 3
+            $results.Add([PSCustomObject]@{
+                Name    = $parts[0].Trim()
+                ID      = if ($hasThreeParts) { $parts[1].Trim() } else { $parts[0].Trim() }
+                Version = if ($hasThreeParts) { $parts[2].Trim() } else { $parts[1].Trim() }
+                Source  = "winget"
+                Manager = "winget"
+            })
         }
         return $results
     }
@@ -370,18 +364,15 @@ function _pw_parse_scoop_lines
             continue
         }
         $parts = ($line.Trim() -split "\s{2,}").Where({ $_ -ne "" })
-        if ($parts.Count -ge 1 -and $parts[0] -notmatch "^[Nn]ame$|^Source$")
-        {
-            $results.Add([PSCustomObject]@{
-                    Name = $parts[0]; ID = $parts[0]
-                    Version = $(if ($parts.Count -ge 2)
-                        { $parts[1]
-                        } else
-                        { "?"
-                        })
-                    Source = "scoop"; Manager = "scoop"
-                })
+        if ($parts.Count -lt 1 -or $parts[0] -match "^[Nn]ame$|^Source$") {
+            continue
         }
+
+        $results.Add([PSCustomObject]@{
+            Name = $parts[0]; ID = $parts[0]
+            Version = if ($parts.Count -ge 2) { $parts[1] } else { "?" }
+            Source = "scoop"; Manager = "scoop"
+        })
     }
     return ,$results
 }


### PR DESCRIPTION
🎯 What: Extracted boolean conditions and used early returns for adding parsed lines to the results array.

💡 Why: Reduces nesting level from 5 levels deep down to 2-3, making the functions much more readable and testable.

✅ Verification: Verified using PowerShell 7.x running the full Pester test suite, specifically ensuring all test assertions around edge cases and outputs remain successful.

✨ Result: Replaced heavily nested if statements with ternary checks and fast exits, making the code more flat and easier to maintain.

---
*PR created automatically by Jules for task [12004282449941197473](https://jules.google.com/task/12004282449941197473) started by @julesklord*